### PR TITLE
Add user retrieval by ID method

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ users.each do |user|
 end
 ```
 
+### Retrieving a user by id
+
+```ruby
+user_id = 'your_user_id' # Replace 'your_user_id' with the actual user id
+user = client.users.get_by_id(user_id)
+
+puts "User ID: #{user.id}"
+puts "User Display Name: #{user.display_name}"
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/lean_microsoft_graph/resources/users_resource.rb
+++ b/lib/lean_microsoft_graph/resources/users_resource.rb
@@ -22,6 +22,12 @@ module LeanMicrosoftGraph
 
         Users.new(response)
       end
+
+      def get_user_by_id(user_id)
+        response = get_request("users/#{user_id}")
+
+        User.new(response)
+      end
     end
   end
 end

--- a/test/lean_microsoft_graph/resources/users_resource_test.rb
+++ b/test/lean_microsoft_graph/resources/users_resource_test.rb
@@ -39,6 +39,17 @@ class LeanMicrosoftGraph::Resources::UsersResourceTest < Minitest::Test
     assert_nil users.next_batch_reference
   end
 
+  def test_get_user_by_id
+    id = '1'
+    @stubs.get("/users/#{id}") do |_env|
+      [200, {}, { id: id }.to_json]
+    end
+
+    user = @users_resource.get_user_by_id(id)
+
+    assert_equal id, user.id
+  end
+
   def teardown
     @stubs.verify_stubbed_calls
   end


### PR DESCRIPTION
This pull request introduces a new method to retrieve a user by their ID.

### Key Changes:

- **New Method:**
  - Added `get_user_by_id` method to `UsersResource` to fetch a user by their unique ID using a GET request to the Microsoft Graph API.
  
- **Documentation Update:**
  - Updated `README.md` with an example demonstrating how to use the new method to retrieve a user by ID.

- **Automated Tests:**
  - Added a new test in `users_resource_test.rb` to ensure the `get_user_by_id` method works correctly and returns the expected data when fetching a user by ID.


