### PR TITLE
Upgrade faraday from v1 to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Add devcontainer configuration.
+- Automated gem documentation using YARD and GitHub Pages.
 - Added faraday-retry gem for retry middleware support.
 
 ### Changed
 
+- Improved CHANGELOG.md file.
 - Upgraded faraday gem to version 2.12.
 - Updated the README to reflect faraday changes
-
-### Added
-
-- Add devcontainer configuration.
-- Automated gem documentation using YARD and GitHub Pages.
-
-### Changed
-
-- Improved CHANGELOG.md file.
 
 ## [0.3.4] - 2024-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Added faraday-retry gem for retry middleware support.
+
+### Changed
+
+- Upgraded faraday gem to version 2.12.
+- Updated the README to reflect faraday changes
+
+### Added
+
 - Add devcontainer configuration.
 - Automated gem documentation using YARD and GitHub Pages.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,51 +2,39 @@ PATH
   remote: .
   specs:
     lean-microsoft-graph (0.3.4)
-      faraday (~> 1.10)
-      faraday_middleware (~> 1.0)
+      faraday (~> 2.12)
+      faraday-retry (~> 2.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (1.10.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.2)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
+    json (2.9.1)
+    logger (1.6.4)
     minitest (5.25.4)
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
-    multipart-post (2.4.1)
+    net-http (0.6.0)
+      uri
     rack (3.1.8)
     rackup (2.2.1)
       rack (>= 3)
     rake (13.2.1)
     redcarpet (3.6.0)
     ruby2_keywords (0.0.5)
+    uri (1.0.2)
     webrick (1.9.1)
     yard (0.9.37)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,45 +2,33 @@ PATH
   remote: .
   specs:
     lean-microsoft-graph (0.3.4)
-      faraday (~> 1.10)
-      faraday_middleware (~> 1.0)
+      faraday (~> 2.12)
+      faraday-retry (~> 2.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (1.10.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.2)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
-    minitest (5.25.1)
-    mocha (2.4.5)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
+    json (2.9.1)
+    logger (1.6.4)
+    minitest (5.25.4)
+    mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
-    multipart-post (2.4.1)
+    net-http (0.6.0)
+      uri
     rake (13.2.1)
     ruby2_keywords (0.0.5)
+    uri (1.0.2)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LeanMicrosoftGraph
 
-Lean Microsoft Graph is a lightweight gem designed for Ruby developers who need to interact with the Microsoft Graph API but are constrained by the use of Faraday version 1. This gem bridges this gap, providing an interface with Microsoft Graph API.
+Lean Microsoft Graph is a lightweight gem designed for Ruby developers who need to interact with the Microsoft Graph API. This gem bridges this gap, providing an interface with Microsoft Graph API.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LeanMicrosoftGraph
 
-Lean Microsoft Graph is a lightweight gem designed for Ruby developers who need to interact with the Microsoft Graph API but are constrained by the use of Faraday version 1. This gem bridges this gap, providing an interface with Microsoft Graph API.
+Lean Microsoft Graph is a lightweight gem designed for Ruby developers who need to interact with the Microsoft Graph API. This gem bridges this gap, providing an interface with Microsoft Graph API.
 The gem documentation can be found at [https://betogrun.github.io/lean-microsoft-graph](https://betogrun.github.io/lean-microsoft-graph).
 
 ## Installation

--- a/lean-microsoft-graph.gemspec
+++ b/lean-microsoft-graph.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday', '~> 1.10'
-  spec.add_dependency 'faraday_middleware', '~> 1.0'
+  spec.add_dependency 'faraday', '~> 2.12'
+  spec.add_dependency 'faraday-retry', '~> 2.2'
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/lean_microsoft_graph.rb
+++ b/lib/lean_microsoft_graph.rb
@@ -1,5 +1,5 @@
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/retry'
 require 'json'
 
 module LeanMicrosoftGraph

--- a/lib/lean_microsoft_graph/client.rb
+++ b/lib/lean_microsoft_graph/client.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'faraday/retry'
+
 module LeanMicrosoftGraph
   class Client
     def initialize(tenant_id:, client_id:, client_secret:, adapter: Faraday.default_adapter, stubs: nil)

--- a/test/lean_microsoft_graph/resources/token_resource_test.rb
+++ b/test/lean_microsoft_graph/resources/token_resource_test.rb
@@ -1,5 +1,6 @@
 
 require 'test_helper'
+require 'ostruct'
 
 class LeanMicrosoftGraph::Resources::TokenResourceTest < Minitest::Test
   def setup


### PR DESCRIPTION
Update Faraday to Version 2.12

**Summary**
	•	Updated the faraday gem to version 2.12.
	•	Added faraday-retry gem as required by the new version.
	•	Updated the README.

**Changes**
	•	Modified gemspec and Gemfile.lock to upgrade Faraday and include faraday-retry.
	•	Adjusted documentation in the README.