### PR TITLE
Bump gem to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-01-07
+
 ### Added
 
 - Add devcontainer configuration.
@@ -82,6 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Initial release
 
+[0.3.4]: https://github.com/betogrun/lean-microsoft-graph/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/betogrun/lean-microsoft-graph/compare/v0.2.4...v0.3.4
 [0.2.4]: https://github.com/betogrun/lean-microsoft-graph/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/betogrun/lean-microsoft-graph/compare/v0.2.2...v0.2.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lean-microsoft-graph (0.3.4)
+    lean-microsoft-graph (0.4.0)
       faraday (~> 2.12)
       faraday-retry (~> 2.2)
 

--- a/lib/lean_microsoft_graph/version.rb
+++ b/lib/lean_microsoft_graph/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LeanMicrosoftGraph
-  VERSION = "0.3.4"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
This PR includes the following updates and additions to the gem:

Added
- DevContainer configuration for development.
- Automated gem documentation using YARD and GitHub Pages.
- Added faraday-retry gem for retry middleware support.

Changed
- Improved CHANGELOG.md structure.
- Upgraded faraday gem to version 2.12.
- Updated README to reflect changes related to faraday.